### PR TITLE
Visual and usability improvements

### DIFF
--- a/visualization/index.html
+++ b/visualization/index.html
@@ -66,8 +66,7 @@
 
 
       <div class="py-5 bg-light">
-        <div class="container">
-
+        <div class="container-fluid px-5">
           <div class="row">
             <div class="col-md-12">
               <div id="map" class="card mb-4 box-shadow">
@@ -79,6 +78,8 @@
               </div>
             </div>
           </div>
+        </div>
+        <div class="container">
           <div class="row mb-4">
             <div class="col-md-12 mx-auto d-flex flex-column">
               <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
@@ -138,7 +139,7 @@
                     <th>Refugees</th>
                   </tr>
                   <tr ng-repeat="location in locations" ng-if="!location.camp">
-                    <td>{{ location.name }}</td>
+                    <td><a href="#map" ng-click="zoomTo($index)">{{ location.name }}</a></td>
                     <td>{{ location.pop }}</td>
                     <td>{{ location.refugees }}</td>
                   </tr>
@@ -154,7 +155,7 @@
                     <th>Refugees</th>
                   </tr>
                   <tr ng-repeat="location in locations" ng-if="location.camp">
-                    <td>{{ location.name }}</td>
+                    <td><a href="#map" ng-click="zoomTo($index)">{{ location.name }}</a></td>
                     <td>{{ location.capacity }}</td>
                     <td class="{{ location.capacity - 50 <= location.refugees ? 'text-danger' : '' }}">{{ location.refugees }}</td>
                   </tr>

--- a/visualization/public/assets/js/classes.js
+++ b/visualization/public/assets/js/classes.js
@@ -299,6 +299,7 @@ class CircleVisManager
    */
   createLine(link)
   {
+    if (link.refugees === 0 && !link.forced) return;
     let points = [
       [link.from.lat, link.from.lng],
       [link.to.lat, link.to.lng]

--- a/visualization/public/assets/js/controller/flee-vis-controller.js
+++ b/visualization/public/assets/js/controller/flee-vis-controller.js
@@ -13,7 +13,7 @@ app.config(['$provide', function($provide) {
 
 
 app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout', 'mapManager','circleVis', 'heatmapVis', function($scope, $http, $interval, $timeout, mapManager, circleVis, heatmapVis) {
-  $scope.popups = [];
+  $scope.marker = [];
   $scope.playing = false;
   $scope.endStep = 500;
   $scope.ready = false;
@@ -31,8 +31,6 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
   };
   
   $scope.selectedSimulation = $scope.availableSimulations['Mali'];
-    
-    
     /**
    * Retrieves the specified data from the server. Additionally initializes all the marker on the map
    * and stores references to each individual popup to update their text when the model changes.
@@ -47,7 +45,7 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
       circleVis.clearLayers();
       mapManager.cities.clearLayers();
       mapManager.camps.clearLayers();
-      $scope.popups = [];
+      $scope.marker = [];
   
       heatmapVis.setConfig($scope.selectedSimulation.heatmapMax);
       circleVis.setVisualizationOptions($scope.selectedSimulation);
@@ -102,7 +100,7 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
     {
       let location = $scope.locations[i];
       
-      $scope.updatePopup($scope.popups[i], location);
+      $scope.updatePopup($scope.marker[i].getPopup(), location);
       
       if (circleVis.isCircleActive())
       {
@@ -140,7 +138,7 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
         "Refugees: " + location.refugees);
       mapManager.cities.addLayer(marker);
     }
-    $scope.popups.push(marker.getPopup());
+    $scope.marker.push(marker);
   };
   
   /**
@@ -162,6 +160,12 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
         "Refugees: " + location.refugees);
     }
     popup.update();
+  };
+  
+  $scope.zoomTo = function(index) {
+    let location = $scope.locations[index];
+    $scope.marker[index].openPopup();
+    mapManager.map.setView([location.lat, location.lng]);
   };
   
   // Timeline related functions
@@ -279,4 +283,10 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
   $scope.dbg = function() {
     console.log($scope.selectedSimulation);
   };
+  
+  // Events that use functions defined above
+  /**
+   * When activating an overlay (like heatmap) we update the map to already show it on the map.
+   */
+  mapManager.map.on('overlayadd', $scope.myUpdateData);
 }]);


### PR DESCRIPTION
This commit changes the container of the map to fluid so that is as big as the screen size allows it to be. Other minor changes include:
- routes are only drawn if there are more than 0 actors on them
- the names of the locations in the table below the visualization can now be clicked to quickly pan and zoom towards the specific location. This also opens the popup associated with it
- when activating an overlay (f.e. heatmap) it is now shown immediately instead of having to change the timestep