### PR TITLE
Rework routes and display of circles

### DIFF
--- a/car-csv.py
+++ b/car-csv.py
@@ -164,11 +164,5 @@ if __name__ == "__main__":
     assert t == visoutput.addTimeStep()
     visoutput.addLocationDataAtTime(t, e.locations)
 
-
-  max = -1
-  for location in camp_locations:
-    val = d.getMaxFromData(location, last_physical_day)
-    if val > max:
-      max = val
-  visoutput.setMetaData(max, [5.725311, 19.488373], "2013-12-01", "CAR", "CAR visualization")
+  visoutput.setMetaData([5.725311, 19.488373], "2013-12-01", "CAR", "CAR visualization")
   visoutput.saveVisData()

--- a/general_vis.py
+++ b/general_vis.py
@@ -66,13 +66,7 @@ if __name__ == "__main__":
     assert t == visoutput.addTimeStep()
     visoutput.addLocationDataAtTime(t, e.locations)
 
-  max = -1
-  for location in d.header:
-    val = d.getMaxFromData(location, end_time)
-    if val > max:
-      max = val
-
-  visoutput.setMetaData(max, [48.208176,16.373819], "2009-12-24", "General", "General visualization")
+  visoutput.setMetaData([48.208176,16.373819], "2009-12-24", "General", "General visualization")
   visoutput.saveVisData()
   #79 746 24601 14784 38188
 

--- a/maliv2vis.py
+++ b/maliv2vis.py
@@ -333,12 +333,6 @@ if __name__ == "__main__":
     assert t == visoutput.addTimeStep()
     visoutput.addLocationDataAtTime(t, e.locations)
 
-  camp_names = ["Mbera", "Mentao", "Bobo-Dioulasso", "Abala", "Mangaize", "Niamey", "Tabareybarey"]
-  max = -1
-  for location in camp_names:
-    val = d.getMaxFromData(location, last_physical_day)
-    if val > max:
-      max = val
-  visoutput.setMetaData(max, [16.3700359, -2.2900239], "2012-02-29", "Mali", "Mali visualization")
+  visoutput.setMetaData([16.3700359, -2.2900239], "2012-02-29", "Mali", "Mali visualization")
   visoutput.saveVisData()
 

--- a/visualization/public/assets/js/controller/flee-vis-controller.js
+++ b/visualization/public/assets/js/controller/flee-vis-controller.js
@@ -76,9 +76,12 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
       mapManager.camps.clearLayers();
       $scope.marker = [];
   
-      const max_value = Math.log(response.data.meta.max);
-      heatmapVis.setMaxMin(max_value);
-      circleVis.setRadiusMultiplier($scope.maxRadius / max_value);
+      const scaled_max_actor_count = Math.log(response.data.meta.maxForLocation);
+      heatmapVis.setMaxMin(scaled_max_actor_count);
+      circleVis.setRadiusMultiplier($scope.maxRadius / scaled_max_actor_count);
+      
+      circleVis.setupLinkThresholds(response.data.meta.maxForLink);
+      circleVis.setupCircleThresholds(response.data.meta.maxForLocation);
       
       mapManager.map.panTo(response.data.meta.center);
   

--- a/visualization/vis.py
+++ b/visualization/vis.py
@@ -11,6 +11,8 @@ class VisManager:
     if not self.output_file.writable():
       raise ValueError("Cant write to visualization output file")
     self.data = []
+    self.maxForLocation = -1
+    self.maxForLink = -1
 
   def visFormat(self):
     return {
@@ -36,6 +38,8 @@ class VisManager:
         "camp": location.camp,
         "capacity": location.capacity
       })
+      if location.numAgents > self.maxForLocation:
+        self.maxForLocation = location.numAgents
 
       for link in location.links:
         formatted_links.append({
@@ -53,15 +57,18 @@ class VisManager:
           "refugees": link.numAgents,
           "forced": link.forced_redirection
         })
+        if link.numAgents > self.maxForLink:
+          self.maxForLink = link.numAgents
     self.data[t]["locations"] = formatted_locations
     self.data[t]["links"] = formatted_links
 
   def addPersonDataAtTime(self, t, person):
     self.data[t]['actors'].append(person.getVisData())
 
-  def setMetaData(self, maxActorCount, center, startDate, name="Unnamed simulation", description="An unnamed visualization"):
+  def setMetaData(self, center, startDate, name="Unnamed simulation", description="An unnamed visualization"):
     self.metadata = {}
-    self.metadata["max"] = maxActorCount
+    self.metadata["maxForLocation"] = self.maxForLocation
+    self.metadata["maxForLink"] = self.maxForLink
     self.metadata["center"] = center
     self.metadata["start_date"] = startDate
     self.metadata["name"] = name
@@ -69,11 +76,8 @@ class VisManager:
 
 
   def saveVisData(self):
-    if "max" in self.metadata:
-      vis_data = {}
-      vis_data["meta"] = self.metadata
-      vis_data["data"] = self.data
-      json.dump(vis_data, self.output_file)
-    else:
-      json.dump(self.data, self.output_file)
+    vis_data = {}
+    vis_data["meta"] = self.metadata
+    vis_data["data"] = self.data
+    json.dump(vis_data, self.output_file)
     self.output_file.close()


### PR DESCRIPTION
This commit updates the visualization of routes and circles.
Routes no longer increase in weight but instead change color to display how many actors are on specific routes.

Circles no longer change color based on hardcoded thresholds. Instead specific thresholds for the current visualization are calculated, based on the maximum amount of actors in a single location.