### PR TITLE
Add flexible timestep display

### DIFF
--- a/car-csv.py
+++ b/car-csv.py
@@ -6,6 +6,8 @@ import numpy as np
 import outputanalysis.analysis as a
 import sys
 import visualization.vis
+from datetime import datetime
+from datetime import timedelta
 
 def AddInitialRefugees(e, d, loc):
   """ Add the initial refugees to a location, using the location name"""
@@ -100,6 +102,9 @@ if __name__ == "__main__":
   refugees_raw = 0 #raw (interpolated) data from TOTAL UNHCR refugee count only.
 
   visoutput = visualization.vis.VisManager(SimulationSettings.SimulationSettings.DefaultVisPath / "car.json")
+  start_date = datetime(2013, 12, 1)
+  current_date = datetime(2013, 12, 1)
+
   for t in range(0,end_time):
 
     ig.AddNewConflictZones(e,t)
@@ -161,8 +166,9 @@ if __name__ == "__main__":
 
     print(output)
 
-    assert t == visoutput.addTimeStep()
+    assert t == visoutput.addTimeStep(current_date.strftime("%Y-%m-%d"))
     visoutput.addLocationDataAtTime(t, e.locations)
+    current_date = current_date + timedelta(days=1)
 
-  visoutput.setMetaData([5.725311, 19.488373], "2013-12-01", "CAR", "CAR visualization")
+  visoutput.setMetaData([5.725311, 19.488373], start_date.strftime("%Y-%m-%d"), "CAR", "CAR visualization")
   visoutput.saveVisData()

--- a/general_vis.py
+++ b/general_vis.py
@@ -4,6 +4,9 @@ import numpy as np
 import outputanalysis.analysis as a
 import visualization.vis
 from flee import InputGeography
+from datetime import datetime
+from datetime import timedelta
+
 
 """
 Generation 1 code. Incorporates only distance, travel always takes one day.
@@ -38,8 +41,11 @@ if __name__ == "__main__":
   refugee_debt = 0
   refugees_raw = 0 #raw (interpolated) data from TOTAL UNHCR refugee count only.
 
+  # Visualization
   visoutput = visualization.vis.VisManager(flee.SimulationSettings.SimulationSettings.DefaultVisPath / "general.json")
-
+  start_date = datetime(2009, 12, 24)
+  current_date = datetime(2009, 12, 24)
+  # Visualization end
 
   for t in range(0,end_time):
     ig.AddNewConflictZones(e, t)
@@ -63,10 +69,15 @@ if __name__ == "__main__":
 
     e.enact_border_closures(t)
     e.evolve()
-    assert t == visoutput.addTimeStep()
+    # Visualization
+    assert t == visoutput.addTimeStep(current_date.strftime("%Y-%m-%d"))
     visoutput.addLocationDataAtTime(t, e.locations)
+    current_date = current_date + timedelta(days=1)
+    # Visualization end
 
-  visoutput.setMetaData([48.208176,16.373819], "2009-12-24", "General", "General visualization")
+  # Visualization
+  visoutput.setMetaData([48.208176,16.373819], start_date.strftime("%Y-%m-%d"), "General", "General visualization")
   visoutput.saveVisData()
+  # Visualization end
   #79 746 24601 14784 38188
 

--- a/maliv2vis.py
+++ b/maliv2vis.py
@@ -6,6 +6,8 @@ import numpy as np
 import outputanalysis.analysis as a
 import sys
 import visualization.vis
+from datetime import datetime
+from datetime import timedelta
 
 def linkBF(e):
   # bing based
@@ -215,6 +217,9 @@ if __name__ == "__main__":
   t_retrofitted = 0
 
   visoutput = visualization.vis.VisManager()
+  start_date = datetime(2012, 2, 29)
+  current_date = datetime(2012, 2, 29)
+
   for t in range(0,end_time):
 
     e.refresh_conflict_weights()
@@ -330,9 +335,10 @@ if __name__ == "__main__":
       output += ",0,0,0,0,0,0,0"
 
     print(output)
-    assert t == visoutput.addTimeStep()
+    assert t == visoutput.addTimeStep(current_date.strftime("%Y-%m-%d"))
     visoutput.addLocationDataAtTime(t, e.locations)
+    current_date = current_date + timedelta(days=1)
 
-  visoutput.setMetaData([16.3700359, -2.2900239], "2012-02-29", "Mali", "Mali visualization")
+  visoutput.setMetaData([16.3700359, -2.2900239], start_date.strftime("%Y-%m-%d"), "Mali", "Mali visualization")
   visoutput.saveVisData()
 

--- a/visualization/index.html
+++ b/visualization/index.html
@@ -24,11 +24,8 @@
               <p class="text-muted">Visualization of data extracted from and simulated by the <a href="https://github.com/djgroen/flee-release">Flee agent-based modelling toolkit</a>.</p>
             </div>
             <div class="col-sm-4 offset-md-1 py-4">
-              <h4 class="text-white">Contact</h4>
-              <ul class="list-unstyled">
-                <li><a href="#" class="text-white">Author Name</a></li>
-                <li><a href="#" class="text-white">Contact Information</a></li>
-              </ul>
+              <h4 class="text-white">Source Code</h4>
+              <p class="text-muted">View me on <a href="https://github.com/selvex/flee-vis">github</a></p>
             </div>
           </div>
         </div>
@@ -107,7 +104,7 @@
                       </div>
                       <div class="input-group flex-grow-1">
                         <div class="input-group-prepend">
-                          <div class="input-group-text" id="currentDate">{{ formatDate(currentDate) }}</div>
+                          <div class="input-group-text" id="currentDate">{{ currentDate }}</div>
                         </div>
                         <div class="flex-grow-1 d-flex align-content-center vis-slider-container">
                           <input ng-change="myUpdateData()" ng-model="dataSet.currentStep" type="range" min="0" max="{{ dataSet.endStep }}" value="0" class="flex-grow-1 mx-2" id="timeline"  aria-label="Simulation timeline" aria-describedby="timeline">

--- a/visualization/public/assets/js/controller/flee-vis-controller.js
+++ b/visualization/public/assets/js/controller/flee-vis-controller.js
@@ -161,7 +161,7 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
       
       mapManager.map.panTo(response.data.meta.center);
   
-      $scope.startDate = new Date(response.data.meta.start_date);
+      $scope.startDate = response.data.meta.start_date;
       $scope.currentDate = $scope.startDate;
       
       let now = $scope.dataSet.getCurrentData();
@@ -198,7 +198,7 @@ app.controller('fleeVisController', ['$scope', '$http', '$interval', '$timeout',
     }
     $scope.locations = $scope.dataSet.getCurrentData().locations;
     $scope.links = $scope.dataSet.getCurrentData().links;
-    $scope.currentDate = $scope.simStepToDate();
+    $scope.currentDate = $scope.dataSet.getCurrentData().display;
     
     circleVis.reset();
   

--- a/visualization/vis.py
+++ b/visualization/vis.py
@@ -14,15 +14,16 @@ class VisManager:
     self.maxForLocation = -1
     self.maxForLink = -1
 
-  def visFormat(self):
+  def visFormat(self, display=""):
     return {
       'actors': [],
       'locations': [],
-      'links': []
+      'links': [],
+      'display': display
     }
 
-  def addTimeStep(self):
-    self.data.append(self.visFormat())
+  def addTimeStep(self, display=""):
+    self.data.append(self.visFormat(display))
     return len(self.data) - 1
 
   def addLocationDataAtTime(self, t, locations):


### PR DESCRIPTION
This commit adds the format how a timestep should be displayed in the
visualization to each individual timestep. This means that when the data
is generated it has to specify the date format which is going to be
used.

The benefit is that now you can easily add visualizations that f.e. have
1 minute as each timestep where as before you could only visualize
simulations that used days as timesteps.